### PR TITLE
Fix unavailable boost iostreams library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN wget https://dl.bintray.com/boostorg/release/1.64.0/source/boost_1_64_0.tar.
     && ./bootstrap.sh --prefix=/usr/local \
     && echo 'using clang : 4.0 : clang++-4.0 ;' >> project-config.jam \
     && ./b2 -d0 -j4 --with-thread --with-date_time --with-system --with-filesystem --with-program_options \
-       --with-signals --with-serialization --with-chrono --with-test --with-context --with-locale --with-coroutine toolset=clang link=static install \
+       --with-signals --with-serialization --with-chrono --with-test --with-context --with-locale --with-coroutine --with-iostreams toolset=clang link=static install \
     && cd .. && rm -rf boost_1_64_0
 
 RUN wget https://github.com/mongodb/mongo-c-driver/releases/download/1.8.0/mongo-c-driver-1.8.0.tar.gz -O - | tar -xz \


### PR DESCRIPTION
During build there's Boost cant find iostreams library.
```
...
-- Detecting CXX compile features - done
-- Using custom FindBoost.cmake
CMake Error at libraries/fc/CMakeModules/FindBoost.cmake:1129 (message):
  Unable to find the requested Boost libraries.

  Boost version: 1.64.0

  Boost include path: /usr/local/include

  The following Boost libraries could not be found:

          boost_iostreams

  Some (but not all) of the required Boost libraries were found.  You may
  need to install these additional Boost libraries.  Alternatively, set
  BOOST_LIBRARYDIR to the directory containing Boost libraries or BOOST_ROOT
  to the location of Boost.
Call Stack (most recent call first):
  CMakeLists.txt:69 (FIND_PACKAGE)


-- Configuring Eos on Linux
...
```

That PR will fix issue.